### PR TITLE
Mount NFS later

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -223,7 +223,7 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 				return err
 			}
 		}
-	case "ceph":
+	case "ceph", "nfs":
 		// the volume will be actually mounted later on, when network is available
 		if err := createIfNotExists(dest, true); err != nil {
 			return err
@@ -296,7 +296,7 @@ func mountToRootfsWithNetwork(m *configs.Mount, rootfs, mountLabel string) error
 	}
 
 	switch m.Device {
-	case "ceph":
+	case "ceph", "nfs":
 
 		if err := createIfNotExists(dest, true); err != nil {
 			return err
@@ -307,22 +307,28 @@ func mountToRootfsWithNetwork(m *configs.Mount, rootfs, mountLabel string) error
 			modeFlag = "--read-only"
 		}
 
-		if err := DoMountCmd(m.Device, m.Source, dest, []string{modeFlag, "-o", "discard"}); err != nil {
-			return err
-		}
+		if m.Device == "ceph" {
+			if err := DoMountCmd(m.Device, m.Source, dest, []string{modeFlag, "-o", "discard"}); err != nil {
+				return err
+			}
 
-		fsType, err := libcontainerUtils.DeviceHasFilesystem(m.Source)
-		if err != nil {
-			return err
-		}
-		// attempt to resize filesystem if it's ext{234}
-		if matched, _ := regexp.MatchString("ext[234]$", fsType); matched {
-			logrus.Infof("Synchronizing the size of volume %s with fs.", m.Source)
-			resizeOutput, err := exec.Command("resize2fs", m.Source).Output()
+			fsType, err := libcontainerUtils.DeviceHasFilesystem(m.Source)
 			if err != nil {
 				return err
 			}
-			logrus.Infof("Ran resize2fs on device '%s': %s", m.Source, resizeOutput)
+			// attempt to resize filesystem if it's ext{234}
+			if matched, _ := regexp.MatchString("ext[234]$", fsType); matched {
+				logrus.Infof("Synchronizing the size of volume %s with fs.", m.Source)
+				resizeOutput, err := exec.Command("resize2fs", m.Source).Output()
+				if err != nil {
+					return err
+				}
+				logrus.Infof("Ran resize2fs on device '%s': %s", m.Source, resizeOutput)
+			}
+		} else if m.Device == "nfs" {
+			if err := DoMountCmd(m.Device, m.Source, dest, []string{modeFlag, "--bind"}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -326,6 +326,8 @@ func mountToRootfsWithNetwork(m *configs.Mount, rootfs, mountLabel string) error
 				logrus.Infof("Ran resize2fs on device '%s': %s", m.Source, resizeOutput)
 			}
 		} else if m.Device == "nfs" {
+			// Perform a bind mount of the nfs directory already mounted in the host, this is
+			// done after the network is available to preserve the volumes declaration order.
 			if err := DoMountCmd(m.Device, m.Source, dest, []string{modeFlag, "--bind"}); err != nil {
 				return err
 			}


### PR DESCRIPTION
Delay the NFS bind mount of the host directory to preserve the volume mounting order.